### PR TITLE
[WIP] Deduped modules should return the same exports

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -208,7 +208,15 @@ DedupePlugin.prototype.apply = function(compiler) {
 						"default:",
 						this.indent([
 							"// Module is a copy of another module",
-							"modules[i] = modules[modules[i]];",
+							"modules[i] = function(mod) {",
+							this.indent([
+								"return function(module, exports, __webpack_require__) {",
+								this.indent([
+									"module.exports = __webpack_require__(mod);",
+								]),
+								"}",
+							]),
+							"}(modules[i])",
 							"break;"
 						]),
 						"}"


### PR DESCRIPTION
I have changed the dedupe algorithm to return the same exports as the deduped module. This ensures that required modules are identical across package boundaries.

This is really useful in the case of Angular2's dependency injector which uses Classes as Tokens (https://angular.io/docs/js/latest/api/di/Injector-class.html) 
Without this fix, the classes that are `required` are not identical across packages, so the DI Injector treats them as different Tokens.

I'm not sure if I should also update the `plugin("add-module")` section.